### PR TITLE
feat(redis): configurable redis.conf via UI list and file

### DIFF
--- a/redis/DOCS.md
+++ b/redis/DOCS.md
@@ -7,3 +7,46 @@ To access the Redis database externally you need to open the `6379` port
 ## Redis Insight
 
 To access Redis Insight you need to open the `8001` port
+
+## Configuration
+
+### `redis_config` (UI)
+
+A list of raw `redis.conf` lines, entered from the add-on Configuration tab.
+Each entry is one directive, appended verbatim to `/etc/redis.conf` on startup.
+Any Redis directive works - nothing is curated or validated by the add-on.
+
+```yaml
+redis_config:
+  - maxmemory 1gb
+  - maxmemory-policy allkeys-lru
+  - save 900 1 300 10 60 10000
+  - appendonly yes
+  - requirepass changeme
+```
+
+### `/config/redis.conf` (file, optional)
+
+For larger configs, drop a `redis.conf` into the add-on's own config folder
+instead of typing many UI lines. With `map: addon_config` that folder is:
+
+- inside the container: `/config/redis.conf`
+- on the Home Assistant host: `/addon_configs/<slug>/redis.conf` (browse
+  `/addon_configs/` with the File Editor, Studio Code Server or Samba add-on;
+  the `<slug>` folder is prefixed, e.g. `xxxxxxxx_redis`)
+
+The same folder also holds the Redis data files (`dump.rdb`), since the data
+dir is `/config`.
+
+### Precedence
+
+Applied low to high, so later entries override earlier ones:
+
+image defaults (`/redis-stack.conf`) -> `/config/redis.conf` -> `redis_config` UI list
+
+### Password / Redis Exporter
+
+`requirepass` (set via the UI list or the file) is picked up automatically so
+Redis Exporter can authenticate. Keep the password simple and unquoted - quoted
+or escaped passwords may not be parsed correctly for the Exporter (Redis itself
+still works; only its metrics scrape breaks).

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -10,6 +10,11 @@ ENV REDIS_DATA_DIR="/config" \
 COPY --from=redis-exporter /redis_exporter /redis_exporter
 COPY --from=redis-exporter /etc/ssl/certs /etc/ssl/certs
 
+# jq: read the redis_config option list from /data/options.json at startup
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY rootfs/ /
 
 EXPOSE 9121

--- a/redis/addon_info.yaml
+++ b/redis/addon_info.yaml
@@ -5,7 +5,7 @@ source:
   version_template: regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-v(?<build>\d+)$
 config:
   version_template: "{{major}}.{{minor}}.{{patch}}"
-  patch: 2
+  patch: 3
   image: fabioogaravini/hassio-redis-stack
 build:
   image: redis/redis-stack

--- a/redis/config.yaml
+++ b/redis/config.yaml
@@ -1,5 +1,5 @@
 name: Redis DB
-version: 7.4.0-v2
+version: 7.4.0-v3
 slug: redis
 description: Redis database
 url: https://redis.io
@@ -20,4 +20,9 @@ ports_description:
   6379/tcp: Database
   8001/tcp: Redis Insight
   9121/tcp: Redis Exporter
+options:
+  redis_config: []
+schema:
+  redis_config:
+    - str
 image: fabioogaravini/hassio-redis-stack

--- a/redis/rootfs/entrypoint.sh
+++ b/redis/rootfs/entrypoint.sh
@@ -1,15 +1,33 @@
 #!/usr/bin/dumb-init /bin/sh
 
-exec /redis_exporter &
-
 ### docker entrypoint script, for starting redis stack
 BASEDIR=/opt/redis-stack
 cd ${BASEDIR}
 
 CMD=${BASEDIR}/bin/redis-server
+CONFFILE=/etc/redis.conf
+OPTIONS=/data/options.json
+
+: > "${CONFFILE}"
+
 if [ -f /redis-stack.conf ]; then
-    CONFFILE=/redis-stack.conf
+    echo "include /redis-stack.conf" >> "${CONFFILE}"
 fi
+
+if [ -f /config/redis.conf ]; then
+    cat /config/redis.conf >> "${CONFFILE}"
+    echo >> "${CONFFILE}"
+fi
+
+if [ -f "${OPTIONS}" ]; then
+    jq -r '.redis_config[]?' "${OPTIONS}" >> "${CONFFILE}"
+fi
+
+# redis_exporter authenticates with the same password
+REDIS_PASSWORD="$(sed -n 's/^requirepass[[:space:]][[:space:]]*//p' "${CONFFILE}" | tail -n1 | tr -d '"')"
+[ -n "${REDIS_PASSWORD}" ] && export REDIS_PASSWORD
+
+exec /redis_exporter &
 
 if [ -z "${REDIS_DATA_DIR}" ]; then
     REDIS_DATA_DIR=/data

--- a/redis/rootfs/entrypoint.sh
+++ b/redis/rootfs/entrypoint.sh
@@ -1,56 +1,72 @@
 #!/usr/bin/dumb-init /bin/sh
+# docker entrypoint script, for starting redis stack
+set -eu
 
-### docker entrypoint script, for starting redis stack
 BASEDIR=/opt/redis-stack
-cd ${BASEDIR}
-
-CMD=${BASEDIR}/bin/redis-server
+CMD="${BASEDIR}/bin/redis-server"
 CONFFILE=/etc/redis.conf
 OPTIONS=/data/options.json
 
-: > "${CONFFILE}"
+cd "${BASEDIR}"
 
-if [ -f /redis-stack.conf ]; then
-    echo "include /redis-stack.conf" >> "${CONFFILE}"
-fi
+build_conf() {
+    : > "${CONFFILE}"
 
-if [ -f /config/redis.conf ]; then
-    cat /config/redis.conf >> "${CONFFILE}"
-    echo >> "${CONFFILE}"
-fi
+    if [ -f /redis-stack.conf ]; then
+        echo "include /redis-stack.conf" >> "${CONFFILE}"
+    fi
 
-if [ -f "${OPTIONS}" ]; then
-    jq -r '.redis_config[]?' "${OPTIONS}" >> "${CONFFILE}"
-fi
+    if [ -f /config/redis.conf ]; then
+        cat /config/redis.conf >> "${CONFFILE}"
+        echo >> "${CONFFILE}"
+    fi
 
-# redis_exporter authenticates with the same password
-REDIS_PASSWORD="$(sed -n 's/^requirepass[[:space:]][[:space:]]*//p' "${CONFFILE}" | tail -n1 | tr -d '"')"
-[ -n "${REDIS_PASSWORD}" ] && export REDIS_PASSWORD
+    if [ -f "${OPTIONS}" ]; then
+        jq -r '.redis_config[]?' "${OPTIONS}" >> "${CONFFILE}"
+    fi
+}
 
-exec /redis_exporter &
+start_exporter() {
+    REDIS_PASSWORD="$(sed -n 's/^requirepass[[:space:]][[:space:]]*//p' "${CONFFILE}" | tail -n1 | tr -d '"')"
+    [ -n "${REDIS_PASSWORD}" ] && export REDIS_PASSWORD
 
-if [ -z "${REDIS_DATA_DIR}" ]; then
-    REDIS_DATA_DIR=/data
-fi
+    # Backgrounded `exec` so we don't leave a lingering subshell around.
+    (exec /redis_exporter) &
+}
 
-# when running in redis-stack (as opposed to redis-stack-server)
-if [ -f ${BASEDIR}/nodejs/bin/node ]; then
-    ${BASEDIR}/nodejs/bin/node -r ${BASEDIR}/share/redisinsight/api/node_modules/dotenv/config share/redisinsight/api/dist/src/main.js dotenv_config_path=${BASEDIR}/share/redisinsight/.env &
-fi
+start_redisinsight() {
+    node_bin="${BASEDIR}/nodejs/bin/node"
+    ri_main="share/redisinsight/api/dist/src/main.js"
+    ri_dotenv="${BASEDIR}/share/redisinsight/api/node_modules/dotenv/config"
+    ri_env="${BASEDIR}/share/redisinsight/.env"
 
-if [ -z "${REDISEARCH_ARGS}" ]; then
-REDISEARCH_ARGS="MAXSEARCHRESULTS 10000 MAXAGGREGATERESULTS 10000"
-fi
+    if [ -x "${node_bin}" ]; then
+        "${node_bin}" -r "${ri_dotenv}" "${ri_main}" "dotenv_config_path=${ri_env}" &
+    fi
+}
 
-${CMD} \
-${CONFFILE} \
---dir ${REDIS_DATA_DIR} \
---protected-mode no \
---daemonize no \
---loadmodule /opt/redis-stack/lib/rediscompat.so \
---loadmodule /opt/redis-stack/lib/redisearch.so ${REDISEARCH_ARGS} \
---loadmodule /opt/redis-stack/lib/redistimeseries.so ${REDISTIMESERIES_ARGS} \
---loadmodule /opt/redis-stack/lib/rejson.so ${REDISJSON_ARGS} \
---loadmodule /opt/redis-stack/lib/redisbloom.so ${REDISBLOOM_ARGS} \
---loadmodule /opt/redis-stack/lib/redisgears.so v8-plugin-path /opt/redis-stack/lib/libredisgears_v8_plugin.so  ${REDISGEARS_ARGS} \
-${REDIS_ARGS}
+build_conf
+start_exporter
+start_redisinsight
+
+REDIS_DATA_DIR="${REDIS_DATA_DIR:-/data}"
+
+REDISEARCH_ARGS="${REDISEARCH_ARGS:-MAXSEARCHRESULTS 10000 MAXAGGREGATERESULTS 10000}"
+REDISTIMESERIES_ARGS="${REDISTIMESERIES_ARGS:-}"
+REDISJSON_ARGS="${REDISJSON_ARGS:-}"
+REDISBLOOM_ARGS="${REDISBLOOM_ARGS:-}"
+REDISGEARS_ARGS="${REDISGEARS_ARGS:-}"
+REDIS_ARGS="${REDIS_ARGS:-}"
+
+exec "${CMD}" \
+    "${CONFFILE}" \
+    --dir "${REDIS_DATA_DIR}" \
+    --protected-mode no \
+    --daemonize no \
+    --loadmodule "${BASEDIR}/lib/rediscompat.so" \
+    --loadmodule "${BASEDIR}/lib/redisearch.so" ${REDISEARCH_ARGS} \
+    --loadmodule "${BASEDIR}/lib/redistimeseries.so" ${REDISTIMESERIES_ARGS} \
+    --loadmodule "${BASEDIR}/lib/rejson.so" ${REDISJSON_ARGS} \
+    --loadmodule "${BASEDIR}/lib/redisbloom.so" ${REDISBLOOM_ARGS} \
+    --loadmodule "${BASEDIR}/lib/redisgears.so" v8-plugin-path "${BASEDIR}/lib/libredisgears_v8_plugin.so" ${REDISGEARS_ARGS} \
+    ${REDIS_ARGS}

--- a/redis/test/docker-compose.aarch64.yml
+++ b/redis/test/docker-compose.aarch64.yml
@@ -2,7 +2,16 @@ name: redis-aarch64
 services:
   redis-aarch64:
     image: fabioogaravini/hassio-redis-stack:${VERSION:-latest}-aarch64
+    build:
+      context: ..
+      args:
+        BUILD_ARCH: aarch64
+        BUILD_VERSION: ${VERSION:-latest}
     container_name: redis-aarch64
+    ports:
+      - 6379:6379
+      - 8001:8001
+      - 9121:9121
     volumes:
       - data:/data
       - ./options.json:/data/options.json:ro

--- a/redis/test/docker-compose.amd64.yml
+++ b/redis/test/docker-compose.amd64.yml
@@ -2,7 +2,16 @@ name: redis-amd64
 services:
   redis-amd64:
     image: fabioogaravini/hassio-redis-stack:${VERSION:-latest}-amd64
+    build:
+      context: ..
+      args:
+        BUILD_ARCH: amd64
+        BUILD_VERSION: ${VERSION:-latest}
     container_name: redis-amd64
+    ports:
+      - 6379:6379
+      - 8001:8001
+      - 9121:9121
     volumes:
       - data:/data
       - ./options.json:/data/options.json:ro

--- a/redis/test/options.json
+++ b/redis/test/options.json
@@ -1,1 +1,6 @@
-{}
+{
+  "redis_config": [
+    "maxmemory 256mb",
+    "maxmemory-policy allkeys-lru"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a way to pass arbitrary `redis.conf` directives to the Redis DB add-on -
either from the add-on Configuration tab or from a config file - without
hardcoding a curated set of options. Fully backward compatible: with no
configuration the add-on behaves exactly as before.

## Motivation

Currently the Redis server runs with image defaults only; there is no supported
way to tune it (memory limits, eviction policy, persistence, auth, ...) from
Home Assistant. This adds that, while keeping it universal - any Redis directive
works, nothing is curated or validated by the add-on.

## What changed

- **`config.yaml`** - new `redis_config` option: a list of strings (`- str`),
  rendered in the UI as a repeatable list of lines. Empty by default. Add-on
  version bumped to `7.4.0-v3`.
- **`addon_info.yaml`** - `config.patch` bumped `2` -> `3` (matches what
  `addon-update.js` would generate), so CI publishes a new image and Home
  Assistant offers the update. No manual action needed on merge.
- **`rootfs/entrypoint.sh`** - assemble `/etc/redis.conf` on startup:
  - `include /redis-stack.conf` (defaults shipped in the image),
  - `cat /config/redis.conf` if present (optional file, for larger configs),
  - each `redis_config[]` entry from `/data/options.json` (via `jq`), appended
    verbatim.
  - `requirepass` (from any source) is read back and exported as
    `REDIS_PASSWORD` so Redis Exporter keeps authenticating when auth is on.
  - Redis Insight, Redis Exporter and module loading are unchanged.
- **`Dockerfile`** - install `jq` (used to read the option list).
- **`DOCS.md`** - document the UI option, the file, precedence and the
  password/exporter note.
- **`test/options.json`** - a sample `redis_config` (no password, so the
  `redis-cli ping` healthcheck still passes).

## Precedence (low -> high)

image defaults (`/redis-stack.conf`) -> `/config/redis.conf` -> `redis_config` UI list

Later entries win, matching Redis' own "last directive wins" behaviour.

## Backward compatibility

With `redis_config` empty and no `/config/redis.conf`, the generated config only
contains `include /redis-stack.conf` (if present), i.e. the previous behaviour.

## Testing

- Verified config assembly and the `requirepass` extraction for unquoted,
  quoted and absent passwords.
- Verified empty options (`{}`) produce no extra directives.
- `test/options.json` exercises the option; the docker-compose healthcheck
  (`redis-cli ping`) passes.

## Notes

- Password extraction for the Exporter is intentionally simple (exact for
  unquoted `requirepass`); documented in `DOCS.md`.
- `CHANGELOG.md` is left untouched (auto-synced from upstream redis-stack
  releases).