### PR TITLE
fix(n8n): propagate env_vars array entries to n8n process

### DIFF
--- a/n8n/rootfs/etc/s6-overlay/s6-rc.d/init-addon-config/run
+++ b/n8n/rootfs/etc/s6-overlay/s6-rc.d/init-addon-config/run
@@ -7,16 +7,16 @@ echo "  Loading env variables:"
 
 OPTIONS_SOURCE=/data/options.json
 
-jq -r 'keys[]' "${OPTIONS_SOURCE}" | while read -r KEY; do
-    # export key
-    value=$(jq -r --arg key "$KEY" '.[$key]' "${OPTIONS_SOURCE}")
+# Process substitution avoids a subshell so exports persist.
+# env_vars array entries are unpacked into individual KEY=value pairs.
+while IFS="=" read -r KEY VALUE; do
+    [ -z "$KEY" ] && continue
 
-    # Continue for single values
-    line="${KEY}=${value}"
+    line="${KEY}=${VALUE}"
 
     # log redacted config
     case "$KEY" in
-        *PASS*|*SECRET*|*KEY*)
+        *PASS*|*SECRET*|*KEY*|*TOKEN*)
             echo "    ${KEY}=******"
             ;;
         *)
@@ -24,7 +24,8 @@ jq -r 'keys[]' "${OPTIONS_SOURCE}" | while read -r KEY; do
             ;;
     esac
 
-    export line
+    # shellcheck disable=SC2163
+    export "$line"
 
     # set .env
     echo "$line" >> /.env || true
@@ -34,10 +35,20 @@ jq -r 'keys[]' "${OPTIONS_SOURCE}" | while read -r KEY; do
 
     # For s6
     if [ -d /var/run/s6/container_environment ]; then
-        printf "%s" "$value" > /var/run/s6/container_environment/"${KEY}"
+        printf "%s" "$VALUE" > /var/run/s6/container_environment/"${KEY}"
     fi
     echo "export $line" >> ~/.bashrc
-done
+done < <(
+    jq -r '
+        to_entries[]
+        | if .key == "env_vars" then
+            .value[]? | "\(.key)=\(.value|tostring)"
+          else
+            select(.value | type != "object" and type != "array")
+            | "\(.key)=\(.value|tostring)"
+          end
+    ' "${OPTIONS_SOURCE}"
+)
 
 if [ -n "$TZ" ] && [ -f /etc/localtime ]; then
     if [ -f /usr/share/zoneinfo/"$TZ" ]; then

--- a/n8n/test/options.json
+++ b/n8n/test/options.json
@@ -2,5 +2,15 @@
   "N8N_LOG_LEVEL": "info",
   "ssl": true,
   "certfile": "fullchain.pem",
-  "keyfile": "privkey.pem"
+  "keyfile": "privkey.pem",
+  "env_vars": [
+    {
+      "key": "NODE_ENV",
+      "value": "production"
+    },
+    {
+      "key": "DB_TYPE",
+      "value": "postgresdb"
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

Custom environment variables configured via the `env_vars` option in Home Assistant are never propagated to the n8n process. The startup log shows the entire `env_vars` array printed as a single scalar value instead of individual variables being exported:

```
env_vars=[
  {"key": "NODE_ENV", "value": "production"},
  ...
]
```

## Root cause

Three bugs in `n8n/rootfs/etc/s6-overlay/s6-rc.d/init-addon-config/run`:

1. **`env_vars` array not unpacked** - the script iterates top-level keys with `jq -r 'keys[]'`. When it hits `env_vars`, it treats the entire array as a single scalar value. Individual key/value pairs are never exported.

2. **`export line` is wrong** - exports a variable literally named `line` with value `KEY=value`, instead of exporting `KEY` with value `value`. Should be `export "$line"`.

3. **Subshell issue** - `jq | while` runs the loop in a subshell, so `export` calls do not persist to the parent. The s6 `container_environment` file writes compensate for top-level keys, but `env_vars` entries never reach that point.

## Fix

- Switch from `jq | while` pipe to process substitution `< <(...)` to avoid the subshell.
- Use a jq filter that unpacks `env_vars` array entries into individual `KEY=value` lines.
- Fix `export line` to `export "$line"`.
- Add `*TOKEN*` to the redaction patterns (matches the shared `.common` version).
- Update test `options.json` to include `env_vars` entries.